### PR TITLE
Change camelCase to snake_case for twitter handle metagen argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ name: 'Tamas Piros'
     desc = excerpt,
     twitter_card_type = "summary_large_image",
     url = page.url,
-    twitterHandle = twitter,
+    twitter_handle = twitter,
     img = img %}
   </head>
 


### PR DESCRIPTION
In [v1.3.1](https://www.npmjs.com/package/eleventy-plugin-metagen) of `metagen`, the casing for shortcode arguments is snake_case instead of camelCase. This PR fixes the casing for example usage in README.md.